### PR TITLE
fix #12 토큰 인증이 만료되면 모달창 확인버튼을 누를때 로그인화면으로 전환됩니다

### DIFF
--- a/src/containers/Content/Content.js
+++ b/src/containers/Content/Content.js
@@ -454,7 +454,11 @@ class Content extends Component {
     this.setState({ focusWordId: value });
   }
   modalHide = () => {
-    this.setState({ error: false, error_msg: "" })
+    if(this.state.error_msg === '4'){
+      this.setState({ error: false, error_msg: "", viewid:0 });
+    }else{
+      this.setState({ error: false, error_msg: "" });
+    }
   }
   modalText = () => {
     switch (this.state.error_msg) {
@@ -463,7 +467,6 @@ class Content extends Component {
       case 't2':
         return '아이디 또는 패스워드가 올바르지 않습니다';
       case '4':
-        this.setState({ viewid: 0 })
         return '로그아웃 되었습니다 다시 로그인해 주세요';
       case 'n2-1':
         return '노트 이름에 허용되지 않는 문자가 있거나 노트 이름이 너무 깁니다';


### PR DESCRIPTION
```
  modalHide = () => {
    if(this.state.error_msg === '4'){
      this.setState({ error: false, error_msg: "", viewid:0 });
    }else{
      this.setState({ error: false, error_msg: "" });
    }
  }
```
switch문에서 처리했지만 모달창 ,로그인컴포먼트가 모두 함께 로드되어 발생된 문제입니다
모달창을 누를때 인증만료되었을경우 로그인창으로 이동되도록 수정했습니다